### PR TITLE
feat: add volunteer RSVP API endpoints

### DIFF
--- a/src/app/api/volunteer/opportunities/[id]/rsvp/route.ts
+++ b/src/app/api/volunteer/opportunities/[id]/rsvp/route.ts
@@ -1,0 +1,218 @@
+import { and, count, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import db from "@/db";
+import { volunteers } from "@/db/schema";
+import { opportunities, volunteerRsvps } from "@/db/schema/opportunities";
+import { requireAuth } from "@/utils/auth";
+import handleError from "@/utils/handle-error";
+
+/**
+ * POST /api/volunteer/opportunities/[id]/rsvp
+ * RSVP to an opportunity
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await requireAuth();
+
+    // Only volunteers can RSVP
+    if (session.user.role !== "volunteer") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const opportunityId = Number.parseInt(id, 10);
+
+    if (!Number.isInteger(opportunityId) || opportunityId <= 0) {
+      return NextResponse.json(
+        { message: "Invalid opportunity ID" },
+        { status: 400 },
+      );
+    }
+
+    // Get volunteer record for current user
+    const userId = Number.parseInt(session.user.id, 10);
+    const volunteer = await db
+      .select()
+      .from(volunteers)
+      .where(eq(volunteers.userId, userId));
+
+    if (volunteer.length === 0) {
+      return NextResponse.json(
+        { message: "Volunteer profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const volunteerId = volunteer[0].id;
+
+    // Check if opportunity exists and is open
+    const opportunity = await db
+      .select()
+      .from(opportunities)
+      .where(eq(opportunities.id, opportunityId));
+
+    if (opportunity.length === 0) {
+      return NextResponse.json(
+        { message: "Opportunity not found" },
+        { status: 404 },
+      );
+    }
+
+    if (opportunity[0].status !== "open") {
+      return NextResponse.json(
+        { message: "Opportunity is not open for RSVPs" },
+        { status: 400 },
+      );
+    }
+
+    // Check if opportunity is in the future
+    if (new Date(opportunity[0].startDate) <= new Date()) {
+      return NextResponse.json(
+        { message: "Cannot RSVP to past opportunities" },
+        { status: 400 },
+      );
+    }
+
+    // Check if already RSVP'd
+    const existingRsvp = await db
+      .select()
+      .from(volunteerRsvps)
+      .where(
+        and(
+          eq(volunteerRsvps.volunteerId, volunteerId),
+          eq(volunteerRsvps.opportunityId, opportunityId),
+        ),
+      );
+
+    if (existingRsvp.length > 0) {
+      return NextResponse.json(
+        { message: "You have already RSVP'd to this opportunity" },
+        { status: 400 },
+      );
+    }
+
+    // Check if opportunity is full
+    if (opportunity[0].maxVolunteers !== null) {
+      const rsvpCount = await db
+        .select({ count: count() })
+        .from(volunteerRsvps)
+        .where(eq(volunteerRsvps.opportunityId, opportunityId));
+
+      if (rsvpCount[0].count >= opportunity[0].maxVolunteers) {
+        return NextResponse.json(
+          { message: "This opportunity is full" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Create RSVP
+    await db.insert(volunteerRsvps).values({
+      volunteerId,
+      opportunityId,
+      status: "pending",
+    });
+
+    return NextResponse.json(
+      {
+        message: "RSVP created successfully",
+        data: { volunteerId, opportunityId, status: "pending" },
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return NextResponse.json({ error: handleError(error) }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/volunteer/opportunities/[id]/rsvp
+ * Cancel RSVP to an opportunity
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await requireAuth();
+
+    // Only volunteers can cancel RSVPs
+    if (session.user.role !== "volunteer") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const opportunityId = Number.parseInt(id, 10);
+
+    if (!Number.isInteger(opportunityId) || opportunityId <= 0) {
+      return NextResponse.json(
+        { message: "Invalid opportunity ID" },
+        { status: 400 },
+      );
+    }
+
+    // Get volunteer record for current user
+    const userId = Number.parseInt(session.user.id, 10);
+    const volunteer = await db
+      .select()
+      .from(volunteers)
+      .where(eq(volunteers.userId, userId));
+
+    if (volunteer.length === 0) {
+      return NextResponse.json(
+        { message: "Volunteer profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const volunteerId = volunteer[0].id;
+
+    // Check if RSVP exists
+    const existingRsvp = await db
+      .select()
+      .from(volunteerRsvps)
+      .where(
+        and(
+          eq(volunteerRsvps.volunteerId, volunteerId),
+          eq(volunteerRsvps.opportunityId, opportunityId),
+        ),
+      );
+
+    if (existingRsvp.length === 0) {
+      return NextResponse.json({ message: "RSVP not found" }, { status: 404 });
+    }
+
+    // Delete RSVP
+    await db
+      .delete(volunteerRsvps)
+      .where(
+        and(
+          eq(volunteerRsvps.volunteerId, volunteerId),
+          eq(volunteerRsvps.opportunityId, opportunityId),
+        ),
+      );
+
+    return NextResponse.json({
+      message: "RSVP cancelled successfully",
+      data: { volunteerId, opportunityId },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return NextResponse.json({ error: handleError(error) }, { status: 500 });
+  }
+}

--- a/src/app/api/volunteer/opportunities/route.ts
+++ b/src/app/api/volunteer/opportunities/route.ts
@@ -1,0 +1,114 @@
+import { and, count, eq, gt, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import db from "@/db";
+import { opportunities, volunteerRsvps } from "@/db/schema/opportunities";
+import { requireAuth } from "@/utils/auth";
+import handleError from "@/utils/handle-error";
+
+/**
+ * GET /api/volunteer/opportunities
+ * List open opportunities that are not full
+ * Query params: limit, offset, search
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  try {
+    const session = await requireAuth();
+
+    // Only volunteers can browse opportunities
+    if (session.user.role !== "volunteer") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(
+      Math.max(Number.parseInt(searchParams.get("limit") || "20", 10), 1),
+      100,
+    );
+    const offset = Math.max(
+      Number.parseInt(searchParams.get("offset") || "0", 10),
+      0,
+    );
+    const search = searchParams.get("search")?.trim() || "";
+
+    const now = new Date();
+
+    // Build base conditions: open status and future start date
+    const baseConditions = and(
+      eq(opportunities.status, "open"),
+      gt(opportunities.startDate, now),
+    );
+
+    // Get opportunities with RSVP counts using a subquery
+    const rsvpCountSubquery = db
+      .select({
+        opportunityId: volunteerRsvps.opportunityId,
+        rsvpCount: count(volunteerRsvps.volunteerId).as("rsvp_count"),
+      })
+      .from(volunteerRsvps)
+      .groupBy(volunteerRsvps.opportunityId)
+      .as("rsvp_counts");
+
+    // Query opportunities
+    let query = db
+      .select({
+        id: opportunities.id,
+        title: opportunities.title,
+        description: opportunities.description,
+        location: opportunities.location,
+        startDate: opportunities.startDate,
+        endDate: opportunities.endDate,
+        status: opportunities.status,
+        maxVolunteers: opportunities.maxVolunteers,
+        rsvpCount: sql<number>`COALESCE(${rsvpCountSubquery.rsvpCount}, 0)`,
+      })
+      .from(opportunities)
+      .leftJoin(
+        rsvpCountSubquery,
+        eq(opportunities.id, rsvpCountSubquery.opportunityId),
+      )
+      .where(baseConditions)
+      .$dynamic();
+
+    // Apply search filter if provided
+    if (search) {
+      query = query.where(
+        and(
+          baseConditions,
+          sql`(${opportunities.title} ILIKE ${`%${search}%`} OR ${opportunities.description} ILIKE ${`%${search}%`} OR ${opportunities.location} ILIKE ${`%${search}%`})`,
+        ),
+      );
+    }
+
+    // Execute query with pagination
+    const allOpportunities = await query
+      .orderBy(opportunities.startDate)
+      .limit(limit)
+      .offset(offset);
+
+    // Filter out full opportunities (where rsvpCount >= maxVolunteers)
+    const availableOpportunities = allOpportunities.filter((opp) => {
+      if (opp.maxVolunteers === null) return true; // No limit
+      return Number(opp.rsvpCount) < opp.maxVolunteers;
+    });
+
+    // Calculate spots remaining
+    const opportunitiesWithSpots = availableOpportunities.map((opp) => ({
+      ...opp,
+      spotsRemaining:
+        opp.maxVolunteers === null
+          ? null
+          : opp.maxVolunteers - Number(opp.rsvpCount),
+    }));
+
+    return NextResponse.json({ data: opportunitiesWithSpots });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return NextResponse.json({ error: handleError(error) }, { status: 500 });
+  }
+}

--- a/src/app/api/volunteer/rsvps/route.ts
+++ b/src/app/api/volunteer/rsvps/route.ts
@@ -1,0 +1,86 @@
+import { desc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import db from "@/db";
+import { volunteers } from "@/db/schema";
+import { opportunities, volunteerRsvps } from "@/db/schema/opportunities";
+import { requireAuth } from "@/utils/auth";
+import handleError from "@/utils/handle-error";
+
+/**
+ * GET /api/volunteer/rsvps
+ * Get current volunteer's RSVPs with opportunity details
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await requireAuth();
+
+    // Only volunteers can view their RSVPs
+    if (session.user.role !== "volunteer") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Get volunteer record for current user
+    const userId = Number.parseInt(session.user.id, 10);
+    const volunteer = await db
+      .select()
+      .from(volunteers)
+      .where(eq(volunteers.userId, userId));
+
+    if (volunteer.length === 0) {
+      return NextResponse.json(
+        { message: "Volunteer profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const volunteerId = volunteer[0].id;
+
+    // Fetch RSVPs with opportunity details
+    const rsvps = await db
+      .select({
+        opportunityId: volunteerRsvps.opportunityId,
+        rsvpStatus: volunteerRsvps.status,
+        rsvpAt: volunteerRsvps.rsvpAt,
+        notes: volunteerRsvps.notes,
+        opportunityTitle: opportunities.title,
+        opportunityDescription: opportunities.description,
+        opportunityLocation: opportunities.location,
+        opportunityStartDate: opportunities.startDate,
+        opportunityEndDate: opportunities.endDate,
+        opportunityStatus: opportunities.status,
+      })
+      .from(volunteerRsvps)
+      .leftJoin(
+        opportunities,
+        eq(volunteerRsvps.opportunityId, opportunities.id),
+      )
+      .where(eq(volunteerRsvps.volunteerId, volunteerId))
+      .orderBy(desc(opportunities.startDate));
+
+    // Separate into upcoming and past
+    const now = new Date();
+    const upcoming = rsvps.filter(
+      (r) => r.opportunityStartDate && new Date(r.opportunityStartDate) > now,
+    );
+    const past = rsvps.filter(
+      (r) => r.opportunityStartDate && new Date(r.opportunityStartDate) <= now,
+    );
+
+    return NextResponse.json({
+      data: {
+        all: rsvps,
+        upcoming,
+        past,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return NextResponse.json({ error: handleError(error) }, { status: 500 });
+  }
+}


### PR DESCRIPTION
# Description
Added endpoints for: 
- GET /api/volunteer/opportunities - browse open opportunities
- POST /api/volunteer/opportunities/[id]/rsvp - RSVP to opportunity
- DELETE /api/volunteer/opportunities/[id]/rsvp - cancel RSVP
- GET /api/volunteer/rsvps - get volunteer's RSVPs (upcoming/past)
